### PR TITLE
✨ feat/IK: game quiz 컴포넌트 구현

### DIFF
--- a/src/components/CommonButton.js
+++ b/src/components/CommonButton.js
@@ -21,7 +21,7 @@ const Button = styled.button`
     // 정렬 속성
     margin-left: 5.88rem;
     position: absolute;
-    bottom: 8.69rem;
+    bottom: 8rem;
 
     // text prop 속성
     display: flex;

--- a/src/pages/game/Quiz.js
+++ b/src/pages/game/Quiz.js
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 
 import NavBar from "../../components/NavBar";
 import AppBar from "../../components/AppBar";
+import QuizComponent from "./components/QuizComponent";
 import CommonButton from "../../components/CommonButton";
 
 const Quiz = () => {
@@ -17,6 +18,18 @@ const Quiz = () => {
     return (
         <Container>
             <AppBar />
+            <QuizContainer>
+                <QuizComponent />
+                <QuizComponent />
+                <QuizComponent />
+                <QuizComponent />
+                <QuizComponent />
+                <QuizComponent />
+                <QuizComponent />
+                <QuizComponent />
+                <QuizComponent />
+                <QuizComponent />
+            </QuizContainer>
             <CommonButton text="SUBMIT" onClick={goToAnswer}/>
             <NavBar />
         </Container>
@@ -26,3 +39,15 @@ const Quiz = () => {
 export default Quiz;
 
 const Container = styled.div``;
+
+const QuizContainer = styled.div`
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    margin-top: 1.5rem;
+    gap: 1rem;
+
+    overflow-y: scroll;
+    max-height: 34rem;
+    //background-color: red;
+`;

--- a/src/pages/game/Quiz.js
+++ b/src/pages/game/Quiz.js
@@ -19,16 +19,16 @@ const Quiz = () => {
         <Container>
             <AppBar />
             <QuizContainer>
-                <QuizComponent />
-                <QuizComponent />
-                <QuizComponent />
-                <QuizComponent />
-                <QuizComponent />
-                <QuizComponent />
-                <QuizComponent />
-                <QuizComponent />
-                <QuizComponent />
-                <QuizComponent />
+                <QuizComponent quizNum={"1"}/>
+                <QuizComponent quizNum={"2"}/>
+                <QuizComponent quizNum={"3"}/>
+                <QuizComponent quizNum={"4"}/>
+                <QuizComponent quizNum={"5"}/>
+                <QuizComponent quizNum={"6"}/>
+                <QuizComponent quizNum={"7"}/>
+                <QuizComponent quizNum={"8"}/>
+                <QuizComponent quizNum={"9"}/>
+                <QuizComponent quizNum={"10"}/>
             </QuizContainer>
             <CommonButton text="SUBMIT" onClick={goToAnswer}/>
             <NavBar />

--- a/src/pages/game/components/QuizComponent.js
+++ b/src/pages/game/components/QuizComponent.js
@@ -1,0 +1,81 @@
+import React, { useState } from "react";
+import { styled } from "styled-components";
+
+const QuizComponent = () => {  
+    // 선택시 클릭하면 색상 변경
+    const [selectedOption, setSelectedOption] = useState(null);
+    const handleOptionClick = (option) => {
+        setSelectedOption(option);
+    };
+
+    return (
+        <Container>
+            {/* 일단 예시로 암거나 넣어둠 */}
+            <QuizNum>Q1.</QuizNum>
+            <Quiz>Linear Search의 평균 검색 회수는?</Quiz>
+            <OptionContainer>
+                <Option selected={selectedOption === 1} onClick={() => handleOptionClick(1)}>① n－1</Option>
+                <Option selected={selectedOption === 2} onClick={() => handleOptionClick(2)}>② (n＋1)/2</Option>
+                <Option selected={selectedOption === 3} onClick={() => handleOptionClick(3)}>③ n</Option>
+                <Option selected={selectedOption === 4} onClick={() => handleOptionClick(4)}>④ n/2</Option>
+            </OptionContainer>
+        </Container>
+    );
+
+};
+
+export default QuizComponent;
+
+const Container = styled.div`
+    width: 21.875rem;
+    height: 14.4375rem;
+    flex-shrink: 0;
+    border-radius: 0.625rem;
+    border: 1px solid #9BBEC8;
+    background: rgba(210, 236, 250, 0.00);
+`;
+
+const QuizNum = styled.span`
+    width: 2.0625rem;
+    height: 1.125rem;
+    flex-shrink: 0;
+    color: #427D9D;
+    font-size: 0.9375rem;
+    font-weight: 700;
+
+    display: flex;
+    margin-top: 0.88rem;
+    margin-left: 1.12rem;
+`;
+
+const Quiz = styled.span`
+    font-size: 0.9375rem;
+    font-weight: 400;
+
+    display: flex;
+    margin-top: 0.69rem;
+    margin-left: 1.12rem;
+`;
+
+const OptionContainer = styled.div`
+    margin-top: 1.12rem;
+    margin-left: 0.94rem;
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.56rem;
+`;
+
+const Option = styled.div`
+    width: 20rem;
+    height: 1.6875rem;
+    flex-shrink: 0;
+    border-radius: 1.25rem;
+    background: ${({ selected }) => selected ? '#427D9D' : '#E3F3FB'};
+    color: ${({ selected }) => selected ? '#FFFFFF' : '#000000'};
+
+    display: flex;
+    align-items: center;
+    padding-left: 0.5rem;
+    cursor: pointer;
+`;

--- a/src/pages/game/components/QuizComponent.js
+++ b/src/pages/game/components/QuizComponent.js
@@ -1,23 +1,34 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { styled } from "styled-components";
 
-const QuizComponent = () => {  
+const QuizComponent = ({quizNum}) => {  
     // 선택시 클릭하면 색상 변경
     const [selectedOption, setSelectedOption] = useState(null);
     const handleOptionClick = (option) => {
-        setSelectedOption(option);
+        setSelectedOption((prevOption) => {
+            // 다시 클릭하면 선택 해제
+            return prevOption === option ? null : option;
+        });
     };
 
+    // 문제 길이에 따라 Container heigt 늘어나도록 변경
+    useEffect(() => {
+        const container = document.getElementById(`quiz-container-${quizNum}`);
+        if (container) {
+            container.style.height = 'auto';
+        }
+    }, [selectedOption, quizNum]);
+
     return (
-        <Container>
+        <Container id={`quiz-container-${quizNum}`}>
             {/* 일단 예시로 암거나 넣어둠 */}
-            <QuizNum>Q1.</QuizNum>
-            <Quiz>Linear Search의 평균 검색 회수는?</Quiz>
+            <QuizNum>Q{quizNum}.</QuizNum>
+            <Quiz>다음 정규화에 대한 설명으로 틀린 것은? 다음 정규화에 대한 설명으로 틀린 것은? 다음 정규화에 대한 설명으로 틀린 것은? 다음 정규화에 대한 설명으로 틀린 것은?</Quiz>
             <OptionContainer>
-                <Option selected={selectedOption === 1} onClick={() => handleOptionClick(1)}>① n－1</Option>
-                <Option selected={selectedOption === 2} onClick={() => handleOptionClick(2)}>② (n＋1)/2</Option>
-                <Option selected={selectedOption === 3} onClick={() => handleOptionClick(3)}>③ n</Option>
-                <Option selected={selectedOption === 4} onClick={() => handleOptionClick(4)}>④ n/2</Option>
+                <Option selected={selectedOption === 1} onClick={() => handleOptionClick(1)}>① 데이터베이스의 개념적 설계 단계에서 수행한다.</Option>
+                <Option selected={selectedOption === 2} onClick={() => handleOptionClick(2)}>② 데이터 구조의 안정성을 최대화한다.</Option>
+                <Option selected={selectedOption === 3} onClick={() => handleOptionClick(3)}>③ 중복을 배제하여 삽입, 삭제, 갱신 이상의 발생을 방지한다.</Option>
+                <Option selected={selectedOption === 4} onClick={() => handleOptionClick(4)}>④ 데이터 삽입 시 릴레이션을 재구성할 필요성을 줄인다.</Option>
             </OptionContainer>
         </Container>
     );
@@ -28,11 +39,13 @@ export default QuizComponent;
 
 const Container = styled.div`
     width: 21.875rem;
-    height: 14.4375rem;
     flex-shrink: 0;
     border-radius: 0.625rem;
     border: 1px solid #9BBEC8;
     background: rgba(210, 236, 250, 0.00);
+    
+    overflow: visible; // 내용 넘쳐도 보이게
+    padding-bottom: 1rem;
 `;
 
 const QuizNum = styled.span`
@@ -40,7 +53,7 @@ const QuizNum = styled.span`
     height: 1.125rem;
     flex-shrink: 0;
     color: #427D9D;
-    font-size: 0.9375rem;
+    font-size: 1rem;
     font-weight: 700;
 
     display: flex;
@@ -49,12 +62,13 @@ const QuizNum = styled.span`
 `;
 
 const Quiz = styled.span`
-    font-size: 0.9375rem;
-    font-weight: 400;
+    font-size: 0.9rem;
+    font-weight: 700;
 
     display: flex;
     margin-top: 0.69rem;
     margin-left: 1.12rem;
+    margin-right: 1rem;
 `;
 
 const OptionContainer = styled.div`
@@ -64,18 +78,25 @@ const OptionContainer = styled.div`
     display: flex;
     flex-direction: column;
     gap: 0.56rem;
+    overflow-y: auto;
 `;
 
 const Option = styled.div`
     width: 20rem;
-    height: 1.6875rem;
+    min-height: 1.6875rem;
     flex-shrink: 0;
     border-radius: 1.25rem;
     background: ${({ selected }) => selected ? '#427D9D' : '#E3F3FB'};
     color: ${({ selected }) => selected ? '#FFFFFF' : '#000000'};
+    font-size: 0.9rem;
 
     display: flex;
     align-items: center;
     padding-left: 0.5rem;
     cursor: pointer;
+
+    white-space: pre-wrap;
+    padding-top: 0.3rem;
+    padding-right: 0.3rem;
+    padding-bottom: 0.3rem;
 `;

--- a/src/pages/mypage/UserInfo.js
+++ b/src/pages/mypage/UserInfo.js
@@ -1,0 +1,87 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import NavBar from "../../components/NavBar";
+import AppBar from "../../components/AppBar";
+import CommonButton from "../../components/CommonButton";
+
+const UserInfo = () => {
+    const [text, setText] = useState("");
+
+    const handleTextChange = (e) => {
+        setText(e.target.value);
+    };
+
+    return (
+        <Container>
+            <AppBar />
+            <ContentContainer>
+                <InsertInfoDiv>
+                    <InsertHereText
+                        value={text}
+                        onChange={handleTextChange}
+                        placeholder={`사용자 정보 입력\n(이력서)`}
+                    />
+                </InsertInfoDiv>
+            </ContentContainer>
+            <CommonButton text="SAVE" />
+            <NavBar />
+        </Container>
+    );
+};
+
+export default UserInfo;
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+const ContentContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 1.563rem;
+`;
+
+const InsertInfoDiv = styled.div`
+    width: 21.875rem;
+    height: 33.25rem;
+    flex-shrink: 0;
+    border-radius: 0.625rem;
+    border: 0.063 solid #9bbec8;
+    background: rgba(210, 236, 250, 0);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+`;
+
+const InsertHereText = styled.textarea`
+    color: black;
+    text-align: left;
+    font-family: Inter;
+    font-size: 0.938rem;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+    border: none;
+    outline: none;
+    background: transparent;
+    width: 95%;
+    height: 95%;
+    resize: none;
+
+    &::placeholder {
+        position: absolute; /* 추가 */
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        color: #427d9d;
+        text-align: center;
+        font-family: Inter;
+        font-size: 0.938rem;
+        font-style: normal;
+        font-weight: 400;
+        line-height: normal;
+    }
+`;

--- a/src/pages/mypage/components/ProfilePic.js
+++ b/src/pages/mypage/components/ProfilePic.js
@@ -1,0 +1,45 @@
+import styled from "styled-components";
+import MedalImg from "../../../assets/images/level-gold.svg";
+import ProfilePicDummy from "../../../assets/images/profilePicDummy.svg";
+
+const Frame = styled.div`
+    width: 5rem;
+    height: 5rem;
+    flex-shrink: 0;
+    background: url(${ProfilePicDummy}) center / cover no-repeat;
+    box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+    border: none;
+    outline: none;
+    z-index: 0;
+`;
+
+const Medal = styled.div`
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 3.75rem;
+    height: 3.125rem;
+    flex-shrink: 0;
+    background: url(${MedalImg}) center / cover no-repeat;
+    border: none;
+    outline: none;
+    z-index: 1;
+`;
+
+const MainContainer = styled.div`
+    display: flex;
+    position: relative;
+    width: 7.5rem;
+    height: 7.5rem;
+    justify-content: center;
+    align-items: center;
+`;
+
+export default function Component() {
+    return (
+        <MainContainer>
+            <Frame />
+            <Medal />
+        </MainContainer>
+    );
+}

--- a/src/pages/mypage/components/SelectBtn1.js
+++ b/src/pages/mypage/components/SelectBtn1.js
@@ -1,0 +1,46 @@
+import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+
+const Component = () => {
+    const navigate = useNavigate();
+
+    const handleButtonClick = () => {
+        navigate("/userinfo");
+    };
+
+    return (
+        <Button1 onClick={handleButtonClick}>
+            <Text>사용자 정보 입력</Text>
+        </Button1>
+    );
+};
+
+const Button1 = styled.div`
+    width: 18.625rem;
+    height: 3.125rem;
+    flex-shrink: 0;
+    border-radius: 1.25rem;
+    background: #164863;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+`;
+
+const Text = styled.span`
+    color: #fff;
+    font-family: Inter;
+    font-size: 1.25rem;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+    width: 9.063rem;
+    height: 1.375rem;
+    flex-shrink: 0;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+`;
+
+export default Component;

--- a/src/pages/mypage/components/SelectBtn2.js
+++ b/src/pages/mypage/components/SelectBtn2.js
@@ -1,0 +1,37 @@
+import styled from "styled-components";
+
+const Button1 = styled.div`
+    width: 18.625rem;
+    height: 3.125rem;
+    flex-shrink: 0;
+    border-radius: 1.25rem;
+    background: #164863;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+`;
+
+const Text = styled.span`
+    color: #fff;
+    font-family: Inter;
+    font-size: 1.25rem;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+    width: 9.063rem;
+    height: 1.375rem;
+    flex-shrink: 0;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+`;
+
+export default function Component() {
+    return (
+        <Button1>
+            <Text>북마크</Text>
+        </Button1>
+    );
+}

--- a/src/pages/mypage/components/SelectBtn3.js
+++ b/src/pages/mypage/components/SelectBtn3.js
@@ -1,0 +1,37 @@
+import styled from "styled-components";
+
+const Button1 = styled.div`
+    width: 18.625rem;
+    height: 3.125rem;
+    flex-shrink: 0;
+    border-radius: 1.25rem;
+    background: #164863;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+`;
+
+const Text = styled.span`
+    color: #fff;
+    font-family: Inter;
+    font-size: 1.25rem;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+    width: 9.063rem;
+    height: 1.375rem;
+    flex-shrink: 0;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+`;
+
+export default function Component() {
+    return (
+        <Button1>
+            <Text>면접 연습 내역</Text>
+        </Button1>
+    );
+}

--- a/src/pages/mypage/components/SelectBtn4.js
+++ b/src/pages/mypage/components/SelectBtn4.js
@@ -1,0 +1,37 @@
+import styled from "styled-components";
+
+const Button1 = styled.div`
+    width: 18.625rem;
+    height: 3.125rem;
+    flex-shrink: 0;
+    border-radius: 1.25rem;
+    background: #164863;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+`;
+
+const Text = styled.span`
+    color: #fff;
+    font-family: Inter;
+    font-size: 1.25rem;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+    width: 9.063rem;
+    height: 1.375rem;
+    flex-shrink: 0;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+`;
+
+export default function Component() {
+    return (
+        <Button1>
+            <Text>게임 연습 내역</Text>
+        </Button1>
+    );
+}

--- a/src/pages/mypage/index.js
+++ b/src/pages/mypage/index.js
@@ -1,0 +1,44 @@
+import React from "react";
+import styled from "styled-components";
+import NavBar from "../../components/NavBar";
+import AppBar from "../../components/AppBar";
+import ProfilePic from "./components/ProfilePic";
+import SelectBtn1 from "./components/SelectBtn1";
+import SelectBtn2 from "./components/SelectBtn2";
+import SelectBtn3 from "./components/SelectBtn3";
+import SelectBtn4 from "./components/SelectBtn4";
+
+const MyPage = () => {
+    return (
+        <div>
+            <MainContainer>
+                <AppBar />
+                <Container>
+                    <ProfilePic />
+                    <SelectBtn1 />
+                    <SelectBtn2 />
+                    <SelectBtn3 />
+                    <SelectBtn4 />
+                </Container>
+                <NavBar />
+            </MainContainer>
+        </div>
+    );
+};
+
+const MainContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    height: calc(100vh - 10rem);
+`;
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3.125rem;
+`;
+
+export default MyPage;


### PR DESCRIPTION
- 🐛 **마이페이지 폴더명 Mypage → mypage로 변경**
    - 클론 받았을 때 routing error 발생 깃허브에서는 대소문자 구문이 안되는 오류때문… 
    vscode에는 [mypage]로 작업해도 커밋하면 깃허브에 적용이 안됨
    - config 설정 변경으로 해결!
  
- 🎨 **Common Button CSS 수정**
    - 좀 위에 있어서 컨텐츠 컨테이너가 좁아보여서 살짝 밑으로 내리도록 수정 `bottom: 8rem`
    
- ✨ **Quiz 컴포넌트 개발**
    - 퀴즈 문제 컴포넌트 만들고 10개 컴포넌트 감싸는 컨테이너에 max-height 대충 설정해서 스크롤 되도록 구현
    - 각 선택지 option 클릭했을 때 배경색 바뀌도록 함
    - 마우스 올라갔을 때 cursor: pointer로 설정
    - 문제 번호(quizNum) prop 설정, 컴포넌트 재사용 가능하도록 수정
    - 선택한 option 다시 클릭하면 기존 색으로 되돌아가도록 수정
    - 문제 글자 수에 따라 QuizComponent의 전체 높이가 동적으로 조절되도록 수정
    - useEffect 사용하여 컴포넌트 렌더링 될 때마다 콜백 실행
    - `container.style.height = 'auto'`
    - Option의 텍스트가 길어질 때도 높이가 자동으로 늘어나도록 수정
    - 기존 height 삭제, min-height 설정하고 `white-space: pre-warp`